### PR TITLE
🐛 fix: Correção ao sugerir despesas

### DIFF
--- a/lib/features/transactions/infra/data_sources/expense_local_data_source.dart
+++ b/lib/features/transactions/infra/data_sources/expense_local_data_source.dart
@@ -76,7 +76,8 @@ class ExpenseLocalDataSource extends LocalDataSource<ExpenseModel> implements IE
           FROM
             $tableName
           WHERE
-            LOWER(description) LIKE LOWER(?)
+            LOWER(description) LIKE LOWER(?) AND
+            ${Model.deletedAtColumnName} IS NULL
 
           UNION
 
@@ -90,7 +91,8 @@ class ExpenseLocalDataSource extends LocalDataSource<ExpenseModel> implements IE
           FROM
             $creditCardTransactionsTableName
           WHERE
-            LOWER(description) LIKE LOWER(?)
+            LOWER(description) LIKE LOWER(?) AND
+            ${Model.deletedAtColumnName} IS NULL
         )
         GROUP BY description, id_category
         ORDER BY

--- a/lib/shared/infra/data_sources/database_local/database_local.dart
+++ b/lib/shared/infra/data_sources/database_local/database_local.dart
@@ -420,7 +420,9 @@ final class DatabaseLocal implements IDatabaseLocal {
         batch.execute('''
           UPDATE expenses
           SET id_category = '00000000-0000-0000-0000-000000000002'
-          WHERE id_credit_card_transaction IS NOT NULL;
+          WHERE 
+            id_credit_card_transaction IS NOT NULL AND
+            deleted_at IS NULL;
         ''');
       }
 


### PR DESCRIPTION
Estava considerando despesas deletadas além de ter um erro na migração do banco de dados.