### PR TITLE
🐛 fix: Reajuste de saldo

### DIFF
--- a/lib/features/account/domain/use_cases/account_save.dart
+++ b/lib/features/account/domain/use_cases/account_save.dart
@@ -2,6 +2,7 @@ import 'package:finan_master_app/features/account/domain/entities/account_entity
 import 'package:finan_master_app/features/account/domain/repositories/i_account_repository.dart';
 import 'package:finan_master_app/features/account/domain/use_cases/i_account_save.dart';
 import 'package:finan_master_app/shared/exceptions/exceptions.dart';
+import 'package:finan_master_app/shared/extensions/double_extension.dart';
 import 'package:finan_master_app/shared/presentation/ui/app_locale.dart';
 
 class AccountSave implements IAccountSave {
@@ -12,7 +13,7 @@ class AccountSave implements IAccountSave {
   @override
   Future<AccountEntity> save(AccountEntity entity) async {
     if (entity.description.trim().isEmpty) throw ValidationException(R.strings.uninformedDescription);
-    if (entity.initialAmount < 0) throw ValidationException(R.strings.greaterThanZero);
+    if (entity.isNew && entity.initialAmount < 0) throw ValidationException(R.strings.greaterThanZero);
     if (entity.financialInstitution == null) return throw ValidationException(R.strings.uninformedFinancialInstitution);
 
     return await _repository.save(entity);
@@ -20,9 +21,9 @@ class AccountSave implements IAccountSave {
 
   @override
   Future<AccountEntity> changeInitialAmount({required AccountEntity entity, required double readjustmentValue}) async {
-    if (readjustmentValue < 0) throw ValidationException(R.strings.greaterThanZero);
+    if (readjustmentValue == 0) throw ValidationException(R.strings.greaterThanZero);
 
-    entity.initialAmount = readjustmentValue;
+    entity.initialAmount = (entity.initialAmount + readjustmentValue).toRound(2);
 
     return await save(entity);
   }

--- a/lib/features/account/presentation/ui/components/readjust_balance.dart
+++ b/lib/features/account/presentation/ui/components/readjust_balance.dart
@@ -211,11 +211,7 @@ class _ReadjustBalanceState extends State<ReadjustBalance> with ThemeContext {
         final bool confirm = await ConfirmReadjustBalanceDialog.show(context: context, accountEntity: notifier.account, value: difference, option: readjustmentOption.value);
         if (!confirm) return;
 
-        await notifier.readjustBalance(
-          readjustmentValue: readjustmentOption.value == ReadjustmentOptionEnum.changeInitialAmount ? readjustmentValue : difference,
-          option: readjustmentOption.value,
-          description: transactionDescription?.isNotEmpty == true ? transactionDescription! : strings.readjustmentTransaction,
-        );
+        await notifier.readjustBalance(readjustmentValue: difference, option: readjustmentOption.value, description: transactionDescription?.isNotEmpty == true ? transactionDescription! : strings.readjustmentTransaction,);
 
         if (notifier.value is ErrorAccountState) throw Exception((notifier.value as ErrorAccountState).message);
 


### PR DESCRIPTION
A correção realizada anteriormente, estava incorreta. O valor valor digitado era setado diretamente no valor inicial da conta, quando deveria usar a diferença e diminuir pelo valor inicial.